### PR TITLE
Add teller and personal banker game modes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 import Phaser from 'phaser';
 import BootScene from './scenes/BootScene';
+import TellerScene from './scenes/TellerScene';
+import PersonalBankerScene from './scenes/PersonalBankerScene';
 
 const config = {
   type: Phaser.AUTO,
@@ -18,7 +20,7 @@ const config = {
     }
   },
   backgroundColor: '#1a1e36',
-  scene: [BootScene]
+  scene: [BootScene, TellerScene, PersonalBankerScene]
 };
 
 const game = new Phaser.Game(config);

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -35,17 +35,21 @@ export default class BootScene extends Phaser.Scene {
     const buttonStartY = height * 0.4;
     const buttonSpacing = height * 0.1;
 
-    // Create buttons
-    this.createButton(centerX, buttonStartY, 'Start Game', () => {
-      console.log('Starting game...');
-      // this.scene.start('GameScene');
+    // Create buttons for game modes
+    this.createButton(centerX, buttonStartY, 'Teller Mode', () => {
+      this.scene.start('TellerScene');
     });
 
-    this.createButton(centerX, buttonStartY + buttonSpacing, 'Load Game', () => {
+    this.createButton(centerX, buttonStartY + buttonSpacing, 'Personal Banker Mode', () => {
+      this.scene.start('PersonalBankerScene');
+    });
+
+    // Additional placeholder buttons
+    this.createButton(centerX, buttonStartY + (buttonSpacing * 2), 'Load Game', () => {
       console.log('Load Game functionality not implemented yet.');
     });
 
-    this.createButton(centerX, buttonStartY + (buttonSpacing * 2), 'Options', () => {
+    this.createButton(centerX, buttonStartY + (buttonSpacing * 3), 'Options', () => {
       console.log('Options functionality not implemented yet.');
     });
 

--- a/src/scenes/PersonalBankerScene.js
+++ b/src/scenes/PersonalBankerScene.js
@@ -1,0 +1,36 @@
+export default class PersonalBankerScene extends Phaser.Scene {
+  constructor() {
+    super('PersonalBankerScene');
+  }
+
+  create() {
+    this.add.text(10, 10, 'Personal Banker Mode', { fontSize: '32px', color: '#ffffff' });
+    this.applications = [
+      { type: 'loan', amount: 10000, business: true },
+      { type: 'checking', business: false },
+      { type: 'savings', business: true },
+      { type: 'cd', term: 12, business: false }
+    ];
+
+    this.applications.forEach((app, index) => {
+      const message = this.handleApplication(app);
+      this.add.text(10, 60 + index * 20, message, { fontSize: '20px', color: '#ffffff' });
+    });
+  }
+
+  handleApplication(app) {
+    const target = app.business ? 'business' : 'personal';
+    switch (app.type) {
+      case 'loan':
+        return `Processed ${target} loan for $${app.amount}`;
+      case 'checking':
+        return `Opened ${target} checking account`;
+      case 'savings':
+        return `Opened ${target} savings account`;
+      case 'cd':
+        return `Opened ${target} CD for ${app.term} months`;
+      default:
+        return 'Unknown application';
+    }
+  }
+}

--- a/src/scenes/TellerScene.js
+++ b/src/scenes/TellerScene.js
@@ -1,0 +1,35 @@
+export default class TellerScene extends Phaser.Scene {
+  constructor() {
+    super('TellerScene');
+    this.balance = 0;
+  }
+
+  create() {
+    this.add.text(10, 10, 'Teller Mode', { fontSize: '32px', color: '#ffffff' });
+    this.customers = [
+      { type: 'deposit', amount: 100 },
+      { type: 'withdrawal', amount: 50 },
+      { type: 'suspicious', amount: 1000 }
+    ];
+
+    this.customers.forEach((customer, index) => {
+      const message = this.handleCustomer(customer);
+      this.add.text(10, 60 + index * 20, message, { fontSize: '20px', color: '#ffffff' });
+    });
+  }
+
+  handleCustomer(customer) {
+    switch (customer.type) {
+      case 'deposit':
+        this.balance += customer.amount;
+        return `Deposited $${customer.amount}`;
+      case 'withdrawal':
+        this.balance -= customer.amount;
+        return `Withdrew $${customer.amount}`;
+      case 'suspicious':
+        return `Flagged suspicious customer with $${customer.amount}`;
+      default:
+        return 'Unknown transaction';
+    }
+  }
+}

--- a/tests/BootScene.test.js
+++ b/tests/BootScene.test.js
@@ -53,4 +53,13 @@ describe('BootScene', () => {
     expect(scene.scale.on).toHaveBeenCalledWith('resize', scene.resize, scene);
     expect(scene.gridSize).toBe(Math.min(scene.scale.width, scene.scale.height) / 20);
   });
+
+  test('creates buttons for both game modes', () => {
+    const scene = createScene();
+    scene.create();
+
+    const labels = scene.createButton.mock.calls.map(call => call[2]);
+    expect(labels).toContain('Teller Mode');
+    expect(labels).toContain('Personal Banker Mode');
+  });
 });

--- a/tests/PersonalBankerScene.test.js
+++ b/tests/PersonalBankerScene.test.js
@@ -1,0 +1,21 @@
+const PhaserStub = {
+  Scene: class {}
+};
+
+global.Phaser = PhaserStub;
+
+describe('PersonalBankerScene', () => {
+  let PersonalBankerScene;
+
+  beforeAll(async () => {
+    PersonalBankerScene = (await import('../src/scenes/PersonalBankerScene.js')).default;
+  });
+
+  test('handles different banking applications', () => {
+    const scene = new PersonalBankerScene();
+    expect(scene.handleApplication({ type: 'loan', amount: 5000, business: false })).toBe('Processed personal loan for $5000');
+    expect(scene.handleApplication({ type: 'checking', business: true })).toBe('Opened business checking account');
+    expect(scene.handleApplication({ type: 'savings', business: false })).toBe('Opened personal savings account');
+    expect(scene.handleApplication({ type: 'cd', term: 12, business: true })).toBe('Opened business CD for 12 months');
+  });
+});

--- a/tests/TellerScene.test.js
+++ b/tests/TellerScene.test.js
@@ -1,0 +1,25 @@
+const PhaserStub = {
+  Scene: class {}
+};
+
+global.Phaser = PhaserStub;
+
+describe('TellerScene', () => {
+  let TellerScene;
+
+  beforeAll(async () => {
+    TellerScene = (await import('../src/scenes/TellerScene.js')).default;
+  });
+
+  test('processes deposits, withdrawals and suspicious customers', () => {
+    const scene = new TellerScene();
+    expect(scene.handleCustomer({ type: 'deposit', amount: 100 })).toBe('Deposited $100');
+    expect(scene.balance).toBe(100);
+
+    expect(scene.handleCustomer({ type: 'withdrawal', amount: 40 })).toBe('Withdrew $40');
+    expect(scene.balance).toBe(60);
+
+    expect(scene.handleCustomer({ type: 'suspicious', amount: 5000 })).toBe('Flagged suspicious customer with $5000');
+    expect(scene.balance).toBe(60);
+  });
+});


### PR DESCRIPTION
## Summary
- Add teller and personal banker game modes with simple processing logic
- Wire game modes into BootScene and main config
- Test new scenes and menu buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b7a94f3883219592b6974406ddd5