### PR TITLE
feat: import Phaser in BootScene

### DIFF
--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -1,3 +1,5 @@
+import Phaser from 'phaser';
+
 export default class BootScene extends Phaser.Scene {
   constructor() {
     super('BootScene');

--- a/tests/BootScene.test.js
+++ b/tests/BootScene.test.js
@@ -9,7 +9,7 @@ const PhaserStub = {
   }
 };
 
-global.Phaser = PhaserStub;
+jest.mock('phaser', () => PhaserStub);
 
 describe('BootScene', () => {
   let BootScene;


### PR DESCRIPTION
## Summary
- import Phaser explicitly in `BootScene`
- adjust BootScene test to mock Phaser module

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898b69479d08321a1df93f7779b2cd0