### PR TITLE
fix: import Phaser in BootScene

### DIFF
--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -1,3 +1,5 @@
+import Phaser from 'phaser';
+
 export default class BootScene extends Phaser.Scene {
   constructor() {
     super('BootScene');

--- a/tests/BootScene.test.js
+++ b/tests/BootScene.test.js
@@ -9,7 +9,7 @@ const PhaserStub = {
   }
 };
 
-global.Phaser = PhaserStub;
+jest.mock('phaser', () => PhaserStub);
 
 describe('BootScene', () => {
   let BootScene;


### PR DESCRIPTION
## Summary
- import Phaser directly in BootScene instead of relying on global
- mock Phaser module in BootScene tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b54c5e8c8321a00b9239610d0ce3