### PR TITLE
Configure Vite base path and add Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 export default {
-  base: './',
+  // Use the repository name as the base so built assets resolve correctly on GitHub Pages
+  base: '/bank-simulator-phaser/',
   server: {
     open: true
   }


### PR DESCRIPTION
## Summary
- set Vite `base` to `/bank-simulator-phaser/` for correct asset paths
- add GitHub Actions workflow to build and deploy to Pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898bab128b08321a7788b48a988a69d