### PR TITLE
Add responsive scaling for UI elements

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,15 +8,11 @@ const config = {
   scale: {
     mode: Phaser.Scale.RESIZE,
     parent: 'game',
-    width: '100%',
-    height: '100%',
+    width: window.innerWidth,
+    height: window.innerHeight,
     min: {
       width: 800,
       height: 600
-    },
-    max: {
-      width: 1600,
-      height: 1200
     }
   },
   backgroundColor: '#1a1e36',
@@ -27,5 +23,5 @@ const game = new Phaser.Game(config);
 
 // Handle window resize
 window.addEventListener('resize', () => {
-  game.scale.refresh();
+  game.scale.resize(window.innerWidth, window.innerHeight);
 });

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -7,6 +7,9 @@ export default class BootScene extends Phaser.Scene {
     this.overlay = null;
     this.background = null;
     this.gridGraphics = [];
+    this.title = null;
+    this.buttons = [];
+    this.credits = null;
   }
 
   create() {
@@ -15,52 +18,49 @@ export default class BootScene extends Phaser.Scene {
     const height = this.scale.height;
 
     this.createDynamicBackground(width, height);
-    
+
     // Add semi-transparent overlay
     this.overlay = this.add.graphics();
     this.overlay.fillStyle(0x1a1e36, 0.7);
     this.overlay.fillRect(0, 0, width, height);
 
-    // Center position for title
-    const centerX = width / 2;
-    const titleY = height * 0.2;
-
-    // Add game title
-    const title = this.add.text(centerX, titleY, 'Bank Simulator', {
-      fontSize: `${Math.min(width / 15, 64)}px`,
+    // Create title and credits placeholders
+    this.title = this.add.text(0, 0, 'Bank Simulator', {
+      fontSize: '64px',
       color: '#ffffff',
       fontStyle: 'bold'
     }).setOrigin(0.5);
-    title.setShadow(2, 2, '#000000', 2, true, true);
+    this.title.setShadow(2, 2, '#000000', 2, true, true);
 
-    // Calculate button positions
-    const buttonStartY = height * 0.4;
-    const buttonSpacing = height * 0.1;
-
-    // Create buttons for game modes
-    this.createButton(centerX, buttonStartY, 'Teller Mode', () => {
-      this.scene.start('TellerScene');
-    });
-
-    this.createButton(centerX, buttonStartY + buttonSpacing, 'Personal Banker Mode', () => {
-      this.scene.start('PersonalBankerScene');
-    });
-
-    // Additional placeholder buttons
-    this.createButton(centerX, buttonStartY + (buttonSpacing * 2), 'Load Game', () => {
-      console.log('Load Game functionality not implemented yet.');
-    });
-
-    this.createButton(centerX, buttonStartY + (buttonSpacing * 3), 'Options', () => {
-      console.log('Options functionality not implemented yet.');
-    });
-
-    // Add Credits text
-    const credits = this.add.text(centerX, height * 0.9, 'Created by @jcrump97 and contributors.', {
-      fontSize: `${Math.min(width / 50, 16)}px`,
+    this.credits = this.add.text(0, 0, 'Created by @jcrump97 and contributors.', {
+      fontSize: '16px',
       color: '#ffffff'
     }).setOrigin(0.5);
-    credits.setShadow(1, 1, '#000000', 1, true, true);
+    this.credits.setShadow(1, 1, '#000000', 1, true, true);
+
+    // Create buttons for game modes and placeholders
+    const tellerButton = this.createButton(0, 0, 'Teller Mode', () => {
+      this.scene.start('TellerScene');
+    });
+    if (tellerButton) this.buttons.push(tellerButton);
+
+    const pbButton = this.createButton(0, 0, 'Personal Banker Mode', () => {
+      this.scene.start('PersonalBankerScene');
+    });
+    if (pbButton) this.buttons.push(pbButton);
+
+    const loadButton = this.createButton(0, 0, 'Load Game', () => {
+      console.log('Load Game functionality not implemented yet.');
+    });
+    if (loadButton) this.buttons.push(loadButton);
+
+    const optionsButton = this.createButton(0, 0, 'Options', () => {
+      console.log('Options functionality not implemented yet.');
+    });
+    if (optionsButton) this.buttons.push(optionsButton);
+
+    // Position elements for initial layout
+    this.repositionElements(width, height);
 
     // Handle resize
     this.scale.on('resize', this.resize, this);
@@ -120,8 +120,34 @@ export default class BootScene extends Phaser.Scene {
 
     // Add both background and text to the container
     button.add([background, buttonText]);
-    
+
     return button;
+  }
+
+  // Reposition and scale UI elements based on screen size
+  repositionElements(width, height) {
+    const centerX = width / 2;
+    const titleY = height * 0.2;
+    const buttonStartY = height * 0.4;
+    const buttonSpacing = height * 0.1;
+    const buttonScale = Math.min(width / 800, height / 600);
+
+    if (this.title) {
+      this.title.setFontSize(Math.min(width / 15, 64));
+      this.title.setPosition(centerX, titleY);
+    }
+
+    this.buttons.forEach((button, index) => {
+      if (button) {
+        button.setPosition(centerX, buttonStartY + index * buttonSpacing);
+        button.setScale(buttonScale);
+      }
+    });
+
+    if (this.credits) {
+      this.credits.setFontSize(Math.min(width / 50, 16));
+      this.credits.setPosition(centerX, height * 0.9);
+    }
   }
 
   // Draws a solid-color backdrop and animated grid
@@ -204,6 +230,7 @@ export default class BootScene extends Phaser.Scene {
       }
     }
 
+    this.repositionElements(width, height);
     this.cameras.resize(width, height);
   }
 }

--- a/src/scenes/PersonalBankerScene.js
+++ b/src/scenes/PersonalBankerScene.js
@@ -1,10 +1,14 @@
 export default class PersonalBankerScene extends Phaser.Scene {
   constructor() {
     super('PersonalBankerScene');
+    this.title = null;
+    this.messages = [];
   }
 
   create() {
-    this.add.text(10, 10, 'Personal Banker Mode', { fontSize: '32px', color: '#ffffff' });
+    const width = this.scale.width;
+    const height = this.scale.height;
+    this.title = this.add.text(0, 0, 'Personal Banker Mode', { fontSize: '32px', color: '#ffffff' });
     this.applications = [
       { type: 'loan', amount: 10000, business: true },
       { type: 'checking', business: false },
@@ -12,10 +16,15 @@ export default class PersonalBankerScene extends Phaser.Scene {
       { type: 'cd', term: 12, business: false }
     ];
 
-    this.applications.forEach((app, index) => {
+    this.messages = [];
+    this.applications.forEach((app) => {
       const message = this.handleApplication(app);
-      this.add.text(10, 60 + index * 20, message, { fontSize: '20px', color: '#ffffff' });
+      const text = this.add.text(0, 0, message, { fontSize: '20px', color: '#ffffff' });
+      this.messages.push(text);
     });
+
+    this.reposition(width, height);
+    this.scale.on('resize', this.resize, this);
   }
 
   handleApplication(app) {
@@ -32,5 +41,25 @@ export default class PersonalBankerScene extends Phaser.Scene {
       default:
         return 'Unknown application';
     }
+  }
+
+  reposition(width, height) {
+    const marginX = width * 0.02;
+    const marginY = height * 0.02;
+    const lineHeight = Math.min(height * 0.05, 30);
+
+    if (this.title) {
+      this.title.setFontSize(Math.min(width / 25, 32));
+      this.title.setPosition(marginX, marginY);
+    }
+
+    this.messages.forEach((text, index) => {
+      text.setFontSize(Math.min(width / 40, 20));
+      text.setPosition(marginX, marginY + (index + 1) * lineHeight);
+    });
+  }
+
+  resize(gameSize) {
+    this.reposition(gameSize.width, gameSize.height);
   }
 }

--- a/src/scenes/TellerScene.js
+++ b/src/scenes/TellerScene.js
@@ -2,20 +2,29 @@ export default class TellerScene extends Phaser.Scene {
   constructor() {
     super('TellerScene');
     this.balance = 0;
+    this.title = null;
+    this.messages = [];
   }
 
   create() {
-    this.add.text(10, 10, 'Teller Mode', { fontSize: '32px', color: '#ffffff' });
+    const width = this.scale.width;
+    const height = this.scale.height;
+    this.title = this.add.text(0, 0, 'Teller Mode', { fontSize: '32px', color: '#ffffff' });
     this.customers = [
       { type: 'deposit', amount: 100 },
       { type: 'withdrawal', amount: 50 },
       { type: 'suspicious', amount: 1000 }
     ];
 
-    this.customers.forEach((customer, index) => {
+    this.messages = [];
+    this.customers.forEach((customer) => {
       const message = this.handleCustomer(customer);
-      this.add.text(10, 60 + index * 20, message, { fontSize: '20px', color: '#ffffff' });
+      const text = this.add.text(0, 0, message, { fontSize: '20px', color: '#ffffff' });
+      this.messages.push(text);
     });
+
+    this.reposition(width, height);
+    this.scale.on('resize', this.resize, this);
   }
 
   handleCustomer(customer) {
@@ -31,5 +40,25 @@ export default class TellerScene extends Phaser.Scene {
       default:
         return 'Unknown transaction';
     }
+  }
+
+  reposition(width, height) {
+    const marginX = width * 0.02;
+    const marginY = height * 0.02;
+    const lineHeight = Math.min(height * 0.05, 30);
+
+    if (this.title) {
+      this.title.setFontSize(Math.min(width / 25, 32));
+      this.title.setPosition(marginX, marginY);
+    }
+
+    this.messages.forEach((text, index) => {
+      text.setFontSize(Math.min(width / 40, 20));
+      text.setPosition(marginX, marginY + (index + 1) * lineHeight);
+    });
+  }
+
+  resize(gameSize) {
+    this.reposition(gameSize.width, gameSize.height);
   }
 }

--- a/tests/BootScene.test.js
+++ b/tests/BootScene.test.js
@@ -30,7 +30,9 @@ describe('BootScene', () => {
     });
     const textMock = () => ({
       setOrigin: jest.fn().mockReturnThis(),
-      setShadow: jest.fn()
+      setShadow: jest.fn(),
+      setFontSize: jest.fn().mockReturnThis(),
+      setPosition: jest.fn().mockReturnThis()
     });
 
     scene.scale = { width: 800, height: 600, on: jest.fn() };


### PR DESCRIPTION
## Summary
- Recalculate BootScene title, buttons, and credits layout when the game window resizes
- Make Teller and Personal Banker scenes position and size text dynamically based on screen dimensions
- Update BootScene tests for new responsive behavior mocks
- Initialize game scale to window size and remove max bounds so the background fills the entire screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898be89d4508321960d0c5f6bc11d23