### PR TITLE
feat: add customer data store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # bank-simulator-phaser
+
+## Data Storage
+
+Customer information is managed client-side using `CustomerStore` located at `src/data/CustomerStore.js`. The store keeps an in-memory map of customers and synchronizes changes to `localStorage` so the game can persist data when hosted on GitHub Pages. Utility methods support loading and saving data, basic CRUD operations, and applying transactions that update account balances. During boot, the store loads any existing data and seeds two example customers if none are found.
  

--- a/src/data/CustomerStore.js
+++ b/src/data/CustomerStore.js
@@ -1,0 +1,99 @@
+export const STORAGE_KEY = 'bank-sim-customers';
+
+// Simple in-memory store with localStorage persistence
+export class CustomerStore {
+  constructor() {
+    this.version = 1;
+    this.customers = new Map();
+  }
+
+  load() {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed.version !== this.version) {
+        // future: handle migrations
+      }
+      this.customers = new Map(parsed.customers.map(c => [c.id, c]));
+    } catch (e) {
+      console.error('Failed to load customers', e);
+    }
+  }
+
+  save() {
+    const customers = Array.from(this.customers.values());
+    const payload = { version: this.version, customers };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }
+
+  addCustomer(customer) {
+    if (!customer.id) {
+      customer.id = `cust-${Date.now()}`;
+    }
+    customer.transactions = customer.transactions || [];
+    this.customers.set(customer.id, customer);
+    this.save();
+    return customer;
+  }
+
+  getCustomer(id) {
+    return this.customers.get(id) || null;
+  }
+
+  updateCustomer(id, updates) {
+    const existing = this.customers.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...updates };
+    this.customers.set(id, updated);
+    this.save();
+    return updated;
+  }
+
+  deleteCustomer(id) {
+    const result = this.customers.delete(id);
+    if (result) this.save();
+    return result;
+  }
+
+  addTransaction(id, txn) {
+    const customer = this.customers.get(id);
+    if (!customer) return null;
+    txn.id = txn.id || `txn-${Date.now()}`;
+    txn.timestamp = txn.timestamp || Date.now();
+    customer.transactions = customer.transactions || [];
+    switch (txn.type) {
+      case 'deposit':
+        customer.balance += txn.amount;
+        break;
+      case 'withdrawal':
+        customer.balance -= txn.amount;
+        break;
+      default:
+        break;
+    }
+    customer.transactions.push(txn);
+    this.save();
+    return txn;
+  }
+}
+
+export const customerStore = new CustomerStore();
+
+export function seedSampleCustomers() {
+  if (customerStore.customers.size > 0) return;
+  customerStore.addCustomer({
+    id: 'cust-001',
+    name: 'Alice Smith',
+    accountType: 'checking',
+    balance: 1200.5,
+    transactions: []
+  });
+  customerStore.addCustomer({
+    id: 'cust-002',
+    name: "Bob's Bakery",
+    accountType: 'businessChecking',
+    balance: 5000,
+    transactions: []
+  });
+}

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -1,4 +1,5 @@
 import Phaser from 'phaser';
+import { customerStore, seedSampleCustomers } from '../data/CustomerStore';
 
 export default class BootScene extends Phaser.Scene {
   constructor() {
@@ -13,6 +14,10 @@ export default class BootScene extends Phaser.Scene {
   }
 
   create() {
+    // load any stored customer data and seed defaults
+    customerStore.load();
+    seedSampleCustomers();
+
     // Get screen dimensions
     const width = this.scale.width;
     const height = this.scale.height;

--- a/tests/CustomerStore.test.js
+++ b/tests/CustomerStore.test.js
@@ -1,0 +1,34 @@
+import { CustomerStore, STORAGE_KEY } from '../src/data/CustomerStore.js';
+
+describe('CustomerStore', () => {
+  let store;
+  beforeEach(() => {
+    store = new CustomerStore();
+    window.localStorage.clear();
+  });
+
+  test('adds and retrieves a customer', () => {
+    store.addCustomer({ id: '1', name: 'Alice', accountType: 'checking', balance: 100, transactions: [] });
+    const cust = store.getCustomer('1');
+    expect(cust.name).toBe('Alice');
+  });
+
+  test('persists and loads from localStorage', () => {
+    store.addCustomer({ id: '1', name: 'Alice', accountType: 'checking', balance: 100, transactions: [] });
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+
+    const reloaded = new CustomerStore();
+    reloaded.load();
+    const cust = reloaded.getCustomer('1');
+    expect(cust.balance).toBe(100);
+  });
+
+  test('adds transaction and updates balance', () => {
+    store.addCustomer({ id: '1', name: 'Alice', accountType: 'checking', balance: 100, transactions: [] });
+    store.addTransaction('1', { type: 'deposit', amount: 50 });
+    const cust = store.getCustomer('1');
+    expect(cust.balance).toBe(150);
+    expect(cust.transactions.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a CustomerStore that persists customer data to localStorage
- load and seed example customers during boot
- document the new data storage layer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898cb79c4ec8321a777f10871592bd7