### PR TITLE
Add ledger, RNG, queue, and interest accrual systems

### DIFF
--- a/src/models/DepositAccount.js
+++ b/src/models/DepositAccount.js
@@ -1,0 +1,12 @@
+import Account from './Account.js';
+
+export default class DepositAccount extends Account {
+  constructor(id, name, type, balance = 0, interestRate = 0, accountNumber = null) {
+    super(id, name, type, balance, accountNumber);
+    this.interestRate = interestRate; // annual rate
+  }
+
+  accrueDailyInterest() {
+    return this.balance * this.interestRate / 365;
+  }
+}

--- a/src/models/JournalEntry.js
+++ b/src/models/JournalEntry.js
@@ -1,0 +1,46 @@
+import Posting from './Posting.js';
+
+export default class JournalEntry {
+  constructor(id, description, postings = [], timestamp = new Date()) {
+    this.id = id || crypto.randomUUID();
+    this.description = description;
+    this.timestamp = timestamp;
+    this.postings = postings.map(p => p instanceof Posting ? p : new Posting(p.accountId, p.amount, p.type));
+    Object.freeze(this.postings);
+    this.validate();
+    Object.freeze(this);
+  }
+
+  validate() {
+    if (this.postings.length < 2) {
+      throw new Error('JournalEntry must have at least two postings');
+    }
+    let debits = 0;
+    let credits = 0;
+    this.postings.forEach(p => {
+      if (p.type === 'debit') {
+        debits += p.amount;
+      } else {
+        credits += p.amount;
+      }
+    });
+    if (Math.abs(debits - credits) > 0.0001) {
+      throw new Error(`JournalEntry is not balanced. Debits: ${debits}, Credits: ${credits}`);
+    }
+    return true;
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      description: this.description,
+      postings: this.postings,
+      timestamp: this.timestamp.toISOString()
+    };
+  }
+
+  static fromJSON(data) {
+    const postings = data.postings.map(p => new Posting(p.accountId, p.amount, p.type));
+    return new JournalEntry(data.id, data.description, postings, new Date(data.timestamp));
+  }
+}

--- a/src/models/Posting.js
+++ b/src/models/Posting.js
@@ -1,0 +1,17 @@
+export default class Posting {
+  constructor(accountId, amount, type) {
+    if (!accountId) {
+      throw new Error('accountId is required');
+    }
+    if (amount <= 0) {
+      throw new Error('amount must be positive');
+    }
+    if (type !== 'debit' && type !== 'credit') {
+      throw new Error("type must be 'debit' or 'credit'");
+    }
+    this.accountId = accountId;
+    this.amount = amount;
+    this.type = type;
+    Object.freeze(this);
+  }
+}

--- a/src/services/CustomerManager.js
+++ b/src/services/CustomerManager.js
@@ -1,7 +1,8 @@
 import Customer from '../models/Customer.js';
 
 export default class CustomerManager {
-  constructor() {
+  constructor(rng = Math.random) {
+    this.rng = typeof rng === 'function' ? { next: rng } : rng;
     this.customers = new Map();
     this.nextCustomerId = 1;
     this.customerQueue = [];
@@ -46,6 +47,10 @@ export default class CustomerManager {
     ];
   }
 
+  random() {
+    return this.rng.next();
+  }
+
   createCustomer(firstName, lastName, email, phone, dateOfBirth, riskProfile = 'medium') {
     const customer = new Customer(
       this.nextCustomerId++,
@@ -62,8 +67,8 @@ export default class CustomerManager {
   }
 
   generateRandomCustomer() {
-    const firstName = this.firstNames[Math.floor(Math.random() * this.firstNames.length)];
-    const lastName = this.lastNames[Math.floor(Math.random() * this.lastNames.length)];
+    const firstName = this.firstNames[Math.floor(this.random() * this.firstNames.length)];
+    const lastName = this.lastNames[Math.floor(this.random() * this.lastNames.length)];
     const email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}@example.com`;
     const phone = this.generateRandomPhone();
     const dateOfBirth = this.generateRandomDateOfBirth();
@@ -72,16 +77,16 @@ export default class CustomerManager {
     const customer = this.createCustomer(firstName, lastName, email, phone, dateOfBirth, riskProfile);
     
     // Generate random profile data
-    customer.occupation = this.occupations[Math.floor(Math.random() * this.occupations.length)];
-    customer.income = Math.floor(Math.random() * 150000) + 25000;
-    customer.creditScore = Math.floor(Math.random() * 400) + 300;
+    customer.occupation = this.occupations[Math.floor(this.random() * this.occupations.length)];
+    customer.income = Math.floor(this.random() * 150000) + 25000;
+    customer.creditScore = Math.floor(this.random() * 400) + 300;
     
     // Generate random address
-    const streetNumber = Math.floor(Math.random() * 9999) + 1;
-    const street = this.streets[Math.floor(Math.random() * this.streets.length)];
-    const city = this.cities[Math.floor(Math.random() * this.cities.length)];
+    const streetNumber = Math.floor(this.random() * 9999) + 1;
+    const street = this.streets[Math.floor(this.random() * this.streets.length)];
+    const city = this.cities[Math.floor(this.random() * this.cities.length)];
     const state = this.generateRandomState();
-    const zipCode = Math.floor(Math.random() * 90000) + 10000;
+    const zipCode = Math.floor(this.random() * 90000) + 10000;
     
     customer.address = {
       street: `${streetNumber} ${street}`,
@@ -91,13 +96,13 @@ export default class CustomerManager {
     };
     
     // Add some random risk factors
-    if (Math.random() < 0.3) {
+    if (this.random() < 0.3) {
       customer.addRiskFactor('High debt-to-income ratio', 'medium');
     }
-    if (Math.random() < 0.2) {
+    if (this.random() < 0.2) {
       customer.addRiskFactor('Recent credit inquiries', 'low');
     }
-    if (Math.random() < 0.1) {
+    if (this.random() < 0.1) {
       customer.addRiskFactor('Previous account closure', 'high');
     }
     
@@ -105,21 +110,21 @@ export default class CustomerManager {
   }
 
   generateRandomPhone() {
-    const areaCode = Math.floor(Math.random() * 900) + 100;
-    const prefix = Math.floor(Math.random() * 900) + 100;
-    const lineNumber = Math.floor(Math.random() * 9000) + 1000;
+    const areaCode = Math.floor(this.random() * 900) + 100;
+    const prefix = Math.floor(this.random() * 900) + 100;
+    const lineNumber = Math.floor(this.random() * 9000) + 1000;
     return `(${areaCode}) ${prefix}-${lineNumber}`;
   }
 
   generateRandomDateOfBirth() {
     const start = new Date(1960, 0, 1);
     const end = new Date(2000, 11, 31);
-    const randomDate = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+    const randomDate = new Date(start.getTime() + this.random() * (end.getTime() - start.getTime()));
     return randomDate.toISOString().split('T')[0];
   }
 
   generateRandomRiskProfile() {
-    const rand = Math.random();
+    const rand = this.random();
     if (rand < 0.6) return 'low';
     if (rand < 0.9) return 'medium';
     return 'high';
@@ -133,7 +138,7 @@ export default class CustomerManager {
       'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
       'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'
     ];
-    return states[Math.floor(Math.random() * states.length)];
+    return states[Math.floor(this.random() * states.length)];
   }
 
   addCustomerToQueue(customerId) {

--- a/src/services/InterestAccrualService.js
+++ b/src/services/InterestAccrualService.js
@@ -1,0 +1,28 @@
+import JournalEntry from '../models/JournalEntry.js';
+import Posting from '../models/Posting.js';
+
+export default class InterestAccrualService {
+  constructor(accountManager, ledger) {
+    this.accountManager = accountManager;
+    this.ledger = ledger;
+    this.accounts = [];
+  }
+
+  registerAccount(accountId, rate) {
+    this.accounts.push({ accountId, rate });
+  }
+
+  accrueDailyInterest() {
+    this.accounts.forEach(({ accountId, rate }) => {
+      const account = this.accountManager.getAccount(accountId);
+      if (!account) return;
+      const interest = account.balance * rate / 365;
+      if (interest <= 0) return;
+      const entry = new JournalEntry(null, `Interest accrual for ${accountId}`, [
+        new Posting(accountId, interest, 'credit'),
+        new Posting('interest_expense', interest, 'debit')
+      ]);
+      this.ledger.postEntry(entry);
+    });
+  }
+}

--- a/src/services/Ledger.js
+++ b/src/services/Ledger.js
@@ -1,0 +1,59 @@
+import JournalEntry from '../models/JournalEntry.js';
+
+export default class Ledger {
+  constructor(accountManager) {
+    this.accountManager = accountManager;
+    this.entries = [];
+  }
+
+  postEntry(entry) {
+    const journalEntry = entry instanceof JournalEntry ? entry : new JournalEntry(entry.id, entry.description, entry.postings, entry.timestamp);
+    // Apply postings
+    const applied = [];
+    journalEntry.postings.forEach(p => {
+      const account = this.accountManager.getAccount(p.accountId);
+      if (!account) {
+        throw new Error(`Account ${p.accountId} not found`);
+      }
+      if (p.type === 'debit') {
+        account.debit(p.amount);
+        applied.push({account, amount: p.amount, type: 'debit'});
+      } else {
+        account.credit(p.amount);
+        applied.push({account, amount: p.amount, type: 'credit'});
+      }
+    });
+
+    const balance = this.accountManager.validateBalanceSheet();
+    if (!balance.isBalanced) {
+      // revert
+      applied.forEach(a => {
+        if (a.type === 'debit') {
+          a.account.credit(a.amount);
+        } else {
+          a.account.debit(a.amount);
+        }
+      });
+      throw new Error('Ledger out of balance after posting');
+    }
+
+    this.entries.push(journalEntry);
+    return journalEntry;
+  }
+
+  getEntries() {
+    return [...this.entries];
+  }
+
+  toJSON() {
+    return {
+      entries: this.entries.map(e => e.toJSON())
+    };
+  }
+
+  static fromJSON(data, accountManager) {
+    const ledger = new Ledger(accountManager);
+    ledger.entries = data.entries.map(e => JournalEntry.fromJSON(e));
+    return ledger;
+  }
+}

--- a/src/services/QueueService.js
+++ b/src/services/QueueService.js
@@ -1,0 +1,31 @@
+export default class QueueService {
+  constructor(customerManager, rng, spawnInterval = 5, basePatience = 5) {
+    this.customerManager = customerManager;
+    this.rng = rng;
+    this.spawnInterval = spawnInterval; // number of ticks between spawns
+    this.basePatience = basePatience;
+    this.tickCount = 0;
+    this.queue = [];
+  }
+
+  tick() {
+    this.tickCount++;
+    // spawn new customer at interval
+    if (this.tickCount % this.spawnInterval === 0) {
+      const customer = this.customerManager.generateRandomCustomer();
+      const extra = Math.floor(this.rng.next() * 3); // 0-2 extra patience
+      customer.patience = this.basePatience + extra;
+      this.queue.push(customer);
+    }
+
+    // decay patience
+    this.queue.forEach(c => {
+      c.patience -= 1;
+    });
+    this.queue = this.queue.filter(c => c.patience > 0);
+  }
+
+  nextCustomer() {
+    return this.queue.shift() || null;
+  }
+}

--- a/src/utils/SeededRNG.js
+++ b/src/utils/SeededRNG.js
@@ -1,0 +1,20 @@
+export default class SeededRNG {
+  constructor(seed = Date.now()) {
+    this.seed = seed >>> 0;
+  }
+
+  next() {
+    let t = this.seed += 0x6D2B79F5;
+    t = Math.imul(t ^ t >>> 15, t | 1);
+    t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  }
+
+  toJSON() {
+    return { seed: this.seed >>> 0 };
+  }
+
+  static fromJSON(data) {
+    return new SeededRNG(data.seed);
+  }
+}

--- a/tests/interestAccrual.test.js
+++ b/tests/interestAccrual.test.js
@@ -1,0 +1,21 @@
+import Account from '../src/models/Account.js';
+import DepositAccount from '../src/models/DepositAccount.js';
+import AccountManager from '../src/services/AccountManager.js';
+import Ledger from '../src/services/Ledger.js';
+import InterestAccrualService from '../src/services/InterestAccrualService.js';
+
+test('interest accrual posts balanced journal entry', () => {
+  const am = new AccountManager();
+  am.accounts.clear();
+  am.accounts.set('cash', new Account('cash', 'Cash', 'asset', 1000));
+  am.accounts.set('capital', new Account('capital', 'Capital', 'equity', 0));
+  am.accounts.set('savings', new DepositAccount('savings', 'Savings Deposits', 'liability', 1000, 0.365));
+  am.accounts.set('interest_expense', new Account('interest_expense', 'Interest Expense', 'expense', 0));
+  const ledger = new Ledger(am);
+  const service = new InterestAccrualService(am, ledger);
+  service.registerAccount('savings', 0.365);
+  service.accrueDailyInterest();
+  expect(am.getAccount('savings').balance).toBeCloseTo(1001);
+  expect(am.getAccount('interest_expense').balance).toBeCloseTo(1);
+  expect(ledger.getEntries().length).toBe(1);
+});

--- a/tests/journalEntry.test.js
+++ b/tests/journalEntry.test.js
@@ -1,0 +1,45 @@
+import Account from '../src/models/Account.js';
+import AccountManager from '../src/services/AccountManager.js';
+import JournalEntry from '../src/models/JournalEntry.js';
+import Posting from '../src/models/Posting.js';
+import Ledger from '../src/services/Ledger.js';
+
+test('unbalanced journal entry is rejected', () => {
+  expect(() => {
+    new JournalEntry(null, 'bad', [
+      new Posting('cash', 100, 'debit'),
+      new Posting('capital', 50, 'credit')
+    ]);
+  }).toThrow('JournalEntry is not balanced');
+});
+
+test('balanced entry posts and persists', () => {
+  const am = new AccountManager();
+  am.accounts.clear();
+  am.accounts.set('cash', new Account('cash', 'Cash', 'asset', 100));
+  am.accounts.set('capital', new Account('capital', 'Capital', 'equity', 100));
+  const ledger = new Ledger(am);
+  const entry = new JournalEntry(null, 'investment', [
+    new Posting('cash', 50, 'debit'),
+    new Posting('capital', 50, 'credit')
+  ]);
+  ledger.postEntry(entry);
+  expect(am.getAccount('cash').balance).toBe(150);
+  expect(ledger.getEntries().length).toBe(1);
+});
+
+test('ledger validation prevents imbalance', () => {
+  const am = new AccountManager();
+  am.accounts.clear();
+  am.accounts.set('cash', new Account('cash', 'Cash', 'asset', 100));
+  am.accounts.set('capital', new Account('capital', 'Capital', 'equity', 100));
+  const ledger = new Ledger(am);
+  // force validation failure
+  am.validateBalanceSheet = () => ({ isBalanced: false });
+  const entry = new JournalEntry(null, 'bad', [
+    new Posting('cash', 10, 'debit'),
+    new Posting('capital', 10, 'credit')
+  ]);
+  expect(() => ledger.postEntry(entry)).toThrow('Ledger out of balance');
+  expect(am.getAccount('cash').balance).toBe(100);
+});

--- a/tests/queueService.test.js
+++ b/tests/queueService.test.js
@@ -1,0 +1,20 @@
+import QueueService from '../src/services/QueueService.js';
+
+test('customers spawn and leave with patience decay', () => {
+  const cm = {
+    id: 1,
+    generateRandomCustomer() {
+      return { id: this.id++ };
+    }
+  };
+  const rng = { next: () => 0 }; // deterministic
+  const qs = new QueueService(cm, rng, 2, 2); // spawn every 2 ticks, patience 2
+  qs.tick(); //1
+  qs.tick(); //2 -> spawn customer1 with patience2 then decay ->1
+  expect(qs.queue.length).toBe(1);
+  qs.tick(); //3 -> decay ->0 remove
+  expect(qs.queue.length).toBe(0);
+  qs.tick(); //4 -> spawn customer2
+  const next = qs.nextCustomer();
+  expect(next.id).toBe(2);
+});

--- a/tests/seededRNG.test.js
+++ b/tests/seededRNG.test.js
@@ -1,0 +1,21 @@
+import SeededRNG from '../src/utils/SeededRNG.js';
+import CustomerManager from '../src/services/CustomerManager.js';
+
+test('seeded rng reproducible', () => {
+  const rng1 = new SeededRNG(123);
+  const rng2 = new SeededRNG(123);
+  const seq1 = [rng1.next(), rng1.next(), rng1.next()];
+  const seq2 = [rng2.next(), rng2.next(), rng2.next()];
+  expect(seq1).toEqual(seq2);
+});
+
+test('customer generation reproducible with same seed', () => {
+  const rngA = new SeededRNG(42);
+  const rngB = new SeededRNG(42);
+  const cm1 = new CustomerManager(rngA);
+  const cm2 = new CustomerManager(rngB);
+  const c1 = cm1.generateRandomCustomer();
+  const c2 = cm2.generateRandomCustomer();
+  expect(c1.firstName).toBe(c2.firstName);
+  expect(c1.lastName).toBe(c2.lastName);
+});


### PR DESCRIPTION
## Summary
- implement immutable journal entries and postings with balance checks
- add ledger service that validates balance sheet after each post
- introduce seeded RNG, queue service with patience decay, and interest accrual for deposit accounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b8eb78b3c8321b7c2e5e1e3c363ee