### PR TITLE
feat: add responsive button styles

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -25,6 +25,7 @@ export function initUI(rootDocument = document) {
     const titleSpan = rootDocument.createElement('span');
     titleSpan.textContent = title;
     const closeBtn = rootDocument.createElement('button');
+    closeBtn.className = 'btn';
     closeBtn.textContent = '\u00D7';
     closeBtn.addEventListener('click', () => {
       windowContainer.removeChild(win);
@@ -65,10 +66,12 @@ export function initUI(rootDocument = document) {
     amountInput.step = '0.01';
 
     const depositBtn = rootDocument.createElement('button');
+    depositBtn.className = 'btn';
     depositBtn.textContent = 'Deposit';
     depositBtn.type = 'submit';
 
     const withdrawBtn = rootDocument.createElement('button');
+    withdrawBtn.className = 'btn';
     withdrawBtn.textContent = 'Withdraw';
     withdrawBtn.type = 'button';
 

--- a/style.css
+++ b/style.css
@@ -4,6 +4,12 @@ html, body {
   margin: 0;
   font-family: Arial, sans-serif;
 }
+
+.btn {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
 .top-bar {
   background: #222;
   color: #fff;
@@ -56,7 +62,6 @@ html, body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 1rem;
 }
 .window-content {
   flex: 1;
@@ -67,7 +72,6 @@ html, body {
   background: transparent;
   border: none;
   color: #fff;
-  font-size: 1.2rem;
   cursor: pointer;
 }
 @media (max-width: 600px) {
@@ -83,5 +87,16 @@ html, body {
   }
   .window-header {
     font-size: 0.9rem;
+  }
+  .btn {
+    font-size: 0.9rem;
+    padding: 0.4rem 0.8rem;
+  }
+}
+
+@media (max-width: 400px) {
+  .btn {
+    font-size: 0.8rem;
+    padding: 0.3rem 0.6rem;
   }
 }


### PR DESCRIPTION
## Summary
- introduce reusable `.btn` class and responsive breakpoints for buttons
- apply `.btn` styling to transaction and window controls

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b958dde74832185a4e618d7d9a210