### PR TITLE
Display account and KPI summaries after transactions

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -74,6 +74,21 @@ export function initUI(rootDocument = document) {
 
     const message = rootDocument.createElement('div');
 
+    const infoSection = rootDocument.createElement('div');
+    infoSection.className = 'info-section';
+
+    function updateInfo() {
+      const accountId = accountSelect.value;
+      const balance = accountManager.getAccountBalance(accountId);
+      const { profit, liquidity } = kpiService.getKPIs();
+      infoSection.innerHTML =
+        `<p>Balance: ${balance.toFixed(2)}</p>` +
+        `<p>Profit: ${profit.toFixed(2)}</p>` +
+        `<p>Liquidity: ${liquidity.toFixed(2)}</p>`;
+    }
+
+    accountSelect.addEventListener('change', updateInfo);
+
     function process(type) {
       const accountId = accountSelect.value;
       const amount = parseFloat(amountInput.value);
@@ -92,6 +107,7 @@ export function initUI(rootDocument = document) {
         ledger.postEntry(entry);
         kpiService.onEntryPosted(entry);
         message.textContent = 'Posted';
+        updateInfo();
       } catch (err) {
         message.textContent = 'Error: ' + err.message;
       }
@@ -112,6 +128,8 @@ export function initUI(rootDocument = document) {
     form.appendChild(withdrawBtn);
     container.appendChild(form);
     container.appendChild(message);
+    container.appendChild(infoSection);
+    updateInfo();
     return container;
   }
 

--- a/style.css
+++ b/style.css
@@ -70,6 +70,19 @@ html, body {
   font-size: 1.2rem;
   cursor: pointer;
 }
+
+.info-section {
+  margin-top: 1rem;
+  padding: 0.5rem;
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.info-section p {
+  margin: 0.2rem 0;
+}
 @media (max-width: 600px) {
   .app-icon {
     width: 70px;
@@ -83,5 +96,8 @@ html, body {
   }
   .window-header {
     font-size: 0.9rem;
+  }
+  .info-section {
+    font-size: 0.8rem;
   }
 }

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -4,6 +4,23 @@ const { TextEncoder, TextDecoder } = require('util');
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 const { JSDOM } = require('jsdom');
+
+jest.mock('../src/services/Ledger.js', () => {
+  return jest.fn().mockImplementation((accountManager) => ({
+    postEntry: (entry) => {
+      entry.postings.forEach(p => {
+        const account = accountManager.getAccount(p.accountId);
+        if (p.type === 'debit') {
+          account.debit(p.amount);
+        } else {
+          account.credit(p.amount);
+        }
+      });
+      return entry;
+    }
+  }));
+});
+
 const { initUI } = require('../src/ui.js');
 
 describe('OS-like UI', () => {
@@ -36,5 +53,24 @@ describe('OS-like UI', () => {
     txIcon.click();
     const form = document.querySelector('.window-content form');
     expect(form).not.toBeNull();
+  });
+
+  test('updates balance and KPIs after transaction', () => {
+    const txIcon = document.querySelector('[data-app="transactions"]');
+    txIcon.click();
+
+    const form = document.querySelector('.window-content form');
+    const accountSelect = form.querySelector('select');
+    const amountInput = form.querySelector('input');
+
+    accountSelect.value = 'checking_liability';
+    amountInput.value = '100';
+
+    form.dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+
+    const info = document.querySelector('.info-section');
+    expect(info.textContent).toContain('Balance: 50100.00');
+    expect(info.textContent).toContain('Profit: 0.00');
+    expect(info.textContent).toContain('Liquidity: 60000.00');
   });
 });


### PR DESCRIPTION
## Summary
- Show real-time account balances and KPI metrics in a new info section after posting transactions.
- Style the info section for clarity, including responsive font sizes.
- Test that posting a transaction updates the balance and KPI display.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b959f6a508321a96a2d8553e8cb9e