### PR TITLE
Add customer queue display and tests

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -2,6 +2,7 @@ import AccountManager from './services/AccountManager.js';
 import Ledger from './services/Ledger.js';
 import JournalEntry from './models/JournalEntry.js';
 import KPIService from './services/KPIService.js';
+import renderCustomers from './ui/customers.js';
 
 const accountManager = new AccountManager();
 const ledger = new Ledger(accountManager);
@@ -120,7 +121,11 @@ export function initUI(rootDocument = document) {
     if (!icon) return;
     const app = icon.dataset.app;
     if (app === 'customers') {
-      createWindow('Customers', 'Customer management coming soon.');
+      const sampleQueue = [
+        { name: 'Alice Smith', patience: 5, status: 'waiting' },
+        { name: 'Bob Johnson', patience: 3, status: 'waiting' }
+      ];
+      createWindow('Customers', renderCustomers(rootDocument, sampleQueue));
     } else if (app === 'accounts') {
       createWindow('Accounts', 'Account information coming soon.');
     } else if (app === 'transactions') {

--- a/src/ui/customers.js
+++ b/src/ui/customers.js
@@ -1,0 +1,36 @@
+export default function renderCustomers(rootDocument, customers = []) {
+  const container = rootDocument.createElement('div');
+  container.className = 'customer-list';
+
+  const table = rootDocument.createElement('table');
+  const thead = rootDocument.createElement('thead');
+  const headerRow = rootDocument.createElement('tr');
+  ['Name', 'Patience', 'Status'].forEach(text => {
+    const th = rootDocument.createElement('th');
+    th.textContent = text;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = rootDocument.createElement('tbody');
+  customers.forEach(cust => {
+    const tr = rootDocument.createElement('tr');
+    const nameTd = rootDocument.createElement('td');
+    nameTd.textContent = cust.fullName || cust.name || '';
+    tr.appendChild(nameTd);
+
+    const patienceTd = rootDocument.createElement('td');
+    patienceTd.textContent = cust.patience != null ? cust.patience : '';
+    tr.appendChild(patienceTd);
+
+    const statusTd = rootDocument.createElement('td');
+    statusTd.textContent = cust.status || 'waiting';
+    tr.appendChild(statusTd);
+
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  container.appendChild(table);
+  return container;
+}

--- a/style.css
+++ b/style.css
@@ -70,6 +70,45 @@ html, body {
   font-size: 1.2rem;
   cursor: pointer;
 }
+
+/* customer list */
+.customer-list table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.customer-list th,
+.customer-list td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid #ccc;
+}
+
+@media (max-width: 600px) {
+  .customer-list table,
+  .customer-list thead,
+  .customer-list tbody,
+  .customer-list th,
+  .customer-list td,
+  .customer-list tr {
+    display: block;
+    width: 100%;
+  }
+  .customer-list tr { margin-bottom: 0.5rem; }
+  .customer-list td {
+    padding-left: 50%;
+    position: relative;
+  }
+  .customer-list td::before {
+    content: attr(data-label);
+    position: absolute;
+    left: 0;
+    width: 50%;
+    padding-left: 0.5rem;
+    font-weight: bold;
+    text-align: left;
+  }
+}
 @media (max-width: 600px) {
   .app-icon {
     width: 70px;

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -31,6 +31,13 @@ describe('OS-like UI', () => {
     expect(header.textContent).toContain('Customers');
   });
 
+  test('shows customer list when icon is clicked', () => {
+    const customersIcon = document.querySelector('[data-app="customers"]');
+    customersIcon.click();
+    const rows = document.querySelectorAll('.customer-list tbody tr');
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
   test('shows transaction form', () => {
     const txIcon = document.querySelector('[data-app="transactions"]');
     txIcon.click();


### PR DESCRIPTION
## Summary
- render queued customers with name, patience and status
- show customer list when the Customers icon is clicked
- style customer list with responsive table
- test that clicking the Customers icon reveals the customer list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b95a1a78c8321b4db245e1422bcba